### PR TITLE
change post route to feed

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,7 +25,7 @@ const router = createBrowserRouter([
     element: <SignupPage />,
   },
   {
-    path: "/posts",
+    path: "/feed",
     element: <FeedPage />,
   },
   {

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -9,7 +9,7 @@ function NavBar() {
     return (
         <nav>
             <div className="homeLogo">
-                <a href="/posts">
+                <a href="/feed">
                     <div className="logoContainer">
                         🍉
                     </div>

--- a/frontend/src/pages/Feed/FeedPage.jsx
+++ b/frontend/src/pages/Feed/FeedPage.jsx
@@ -41,7 +41,7 @@ export function FeedPage() {
             key={post._id} 
             message={post.message} 
             dateCreated={post.dateCreated}
-            username={post.user.username}
+            username={post.user?.username}
             noOfLikes={post.noOfLikes}
           />
         ))}

--- a/frontend/src/pages/Login/LoginPage.jsx
+++ b/frontend/src/pages/Login/LoginPage.jsx
@@ -13,7 +13,7 @@ export function LoginPage() {
     try {
       const token = await login(email, password);
       localStorage.setItem("token", token);
-      navigate("/posts");
+      navigate("/feed");
     } catch (err) {
       console.error(err);
       navigate("/login");

--- a/frontend/tests/components/navbar.test.jsx
+++ b/frontend/tests/components/navbar.test.jsx
@@ -69,7 +69,7 @@ test("has correct href for each navigation link", () => {
     </MemoryRouter>
     );
 
-    expect(screen.getByText("Home").closest("a").getAttribute("href")).to.equal("/posts");
+    expect(screen.getByText("Home").closest("a").getAttribute("href")).to.equal("/feed");
     expect(screen.getByText("Profile").closest("a").getAttribute("href")).to.equal("/profile");
     expect(screen.getByText("Friends").closest("a").getAttribute("href")).to.equal("/friends");
     expect(screen.getByText("Messages").closest("a").getAttribute("href")).to.equal("/messages");

--- a/frontend/tests/pages/loginPage.test.jsx
+++ b/frontend/tests/pages/loginPage.test.jsx
@@ -54,7 +54,7 @@ describe("Login Page", () => {
 
     await completeLoginForm();
 
-    expect(navigateMock).toHaveBeenCalledWith("/posts");
+    expect(navigateMock).toHaveBeenCalledWith("/feed");
   });
 
   test("navigates to /login on unsuccessful login", async () => {


### PR DESCRIPTION
We have updated the /posts route to /feed. We changed the nav bar so it correctly routes as well as the login page so it automatically routes to /feed instead of /posts.